### PR TITLE
Use responseType "stream" for /hub/zwaveInfo

### DIFF
--- a/Apps/mesh-details/mesh-details.groovy
+++ b/Apps/mesh-details/mesh-details.groovy
@@ -411,7 +411,7 @@ function loadScripts() {
 function getZwaveList() {
 	const instance = axios.create({
 		timeout: 5000,
-		responseType: "document"
+		responseType: "stream"
 		});
 
 	return instance


### PR DESCRIPTION
Use responseType "stream" rather than "document" for the axios get of /hub/zwaveInfo.
This addresses the empty list seen on some browsers.