### PR TITLE
Update mesh-details.groovy

### DIFF
--- a/Apps/mesh-details/mesh-details.groovy
+++ b/Apps/mesh-details/mesh-details.groovy
@@ -1515,8 +1515,10 @@ function buildNeighborsLists(fullnameMap, nodeData) {
 						neighborsMap.set(devId, [])
 					}
 					n = neighborsMap.get(devId)
-					n.push(neighborId)
-
+ 				        if( neighborId == 1 || neighborId >= 10 ) { 
+					     	n.push(neighborId)
+					}	
+     
 					if (!neighborsMapReverse.has(neighborId)) {
 						neighborsMapReverse.set(neighborId, [])
 					}


### PR DESCRIPTION
I'm running hubitat platform 2.3.8.140 , C8-pro and devices that are connected directly to HUB have neighborID 3 5 7 , which are part of the hub,in addition to devid 1.  but are not present in the list of devices. As the result findDeviceByDecId(neighborId) returns NUL in displayRowDetail() function call and with no handling for NUL object the device details page does not show up at all.