### PR TITLE
Update mesh-details.groovy

### DIFF
--- a/Apps/mesh-details/mesh-details.groovy
+++ b/Apps/mesh-details/mesh-details.groovy
@@ -1551,7 +1551,12 @@ var nonRepeaters = new Set()
 function buildNeighborsLists(fullnameMap, nodeData) {
 	neighborsMap = new Map()
 	neighborsMapReverse = new Map()
+ 	deviceMap = new Map()
 	nonRepeaters = new Set()
+ 	Object.entries(nodeData).forEach(  e1 => {
+		var devId = e1[0]
+        	deviceMap[devId]=1
+	})
 	Object.entries(nodeData).forEach(  e1 => {
 		var devId = e1[0]
 		var detail = e1[1]
@@ -1564,8 +1569,9 @@ function buildNeighborsLists(fullnameMap, nodeData) {
 						neighborsMap.set(devId, [])
 					}
 					n = neighborsMap.get(devId)
-					n.push(neighborId)
-
+     					if(deviceMap[neighborId]) {
+						n.push(neighborId)
+					}
 					if (!neighborsMapReverse.has(neighborId)) {
 						neighborsMapReverse.set(neighborId, [])
 					}


### PR DESCRIPTION
If you think actual devices can have an ID less than 10, what about this change, to check if the neighbor ID exists in the list of devices before adding it to the neighbors list. With the change you are suggesting, device IDs 3,5,7 are still present in the neighborsMap and show up as unknown devices in the device details. But I think this is misleading, it creates an impression that device's zwave table is corrupted and contains invalid device IDs. While it is not true, 3,5,7 are actually hub IDs.